### PR TITLE
chore: Restrict list of supported shells

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 use clap::Parser;
-use clap_complete::Shell;
 
 const DEFAULT_SOCKET: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0);
 
@@ -42,9 +41,27 @@ pub struct RunArgs {
     pub(crate) args: Vec<String>,
 }
 
-
 #[derive(clap::Args, Debug, Clone)]
 pub struct GenerateCompletionArgs {
     #[arg(long, env = "ASSUMER_SHELL")]
     pub(crate) shell: Shell,
+}
+
+#[derive(clap::ValueEnum, Debug, Clone)]
+pub enum Shell {
+    Bash,
+    Fish,
+    Zsh,
+    Elvish,
+}
+
+impl From<Shell> for clap_complete::Shell {
+    fn from(shell: Shell) -> Self {
+        match shell {
+            Shell::Bash => clap_complete::Shell::Bash,
+            Shell::Fish => clap_complete::Shell::Fish,
+            Shell::Zsh => clap_complete::Shell::Zsh,
+            Shell::Elvish => clap_complete::Shell::Elvish,
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use crate::app::AppState;
 use aws_config::BehaviorVersion;
 use axum::Router;
 use clap::CommandFactory;
-use clap_complete::{generate };
+use clap_complete::{generate, Shell};
 use config::{Args, GenerateCompletionArgs, RunArgs};
 use hyper::{body::Incoming, Request};
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -90,7 +90,12 @@ pub async fn setup_server(config: &RunArgs) -> Result<aws_sdk_sts::Client, ()> {
 pub fn run_generate_completion(config: GenerateCompletionArgs) -> Result<(), ()> {
     let shell = config.shell;
     let mut app = Args::command();
-    generate(shell, &mut app, "iam-assumer", &mut std::io::stdout());
+    generate(
+        Shell::from(shell),
+        &mut app,
+        "iam-assumer",
+        &mut std::io::stdout(),
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Basically, we don't currently support powershell cause this doesn't run on windows (yet?)